### PR TITLE
Making the code compatible with Node 0.10.* and 0.12.*

### DIFF
--- a/test/unit/context_adapter_test.js
+++ b/test/unit/context_adapter_test.js
@@ -76,7 +76,6 @@ describe('Context Adapter server:', function() {
           expect(err).to.equal(null);
           expect(response.statusCode).to.equal(400);
           expect(body.statusCode).to.equal(400);
-          expect(response.statusMessage).to.equal('Bad Request');
           expect(body.error).to.equal('Bad Request');
           done();
         }
@@ -94,7 +93,6 @@ describe('Context Adapter server:', function() {
           expect(err).to.equal(null);
           expect(response.statusCode).to.equal(400);
           expect(body.statusCode).to.equal(400);
-          expect(response.statusMessage).to.equal('Bad Request');
           expect(body.error).to.equal('Bad Request');
           done();
         }


### PR DESCRIPTION
It seems boom 0.2.8 (https://www.npmjs.com/package/boom) behaves differently when run using Node 0.10 and Node 0.12. More concretely, it does not include or it includes the "statusMessage" property in the error messages.

To solve the issue, the `statusMessage` assertion has been removed from the tests :)
- 100% tests passed
- Assigned to @dmoranj 
