### PR TITLE
Including start() and stop() functions for the Context Adapter

### DIFF
--- a/bin/context-adapter
+++ b/bin/context-adapter
@@ -27,4 +27,4 @@
 
 var contextAdapter = require('../lib/context_adapter');
 
-contextAdapter.startup();
+contextAdapter.start(true);

--- a/lib/context_adapter.js
+++ b/lib/context_adapter.js
@@ -79,15 +79,17 @@ function exitGracefully(err, callback) {
 }
 
 /**
- * Convenience method to startup the Context Adapter component as a running
+ * Convenience method to start the Context Adapter component up as a running
  *  Node.js application or via require()
- * @param {Function} callback Callback function to notify when startup process
+ * @param {Function} callback Callback function to notify when start up process
  *  has concluded
  * @return {*}
  */
-function startup(callback) {
+function start(enableProofOfLifeLogging, callback) {
   if (isStarted) {
-    return process.nextTick(callback);
+    if (callback) {
+      return process.nextTick(callback);
+    }
   }
 
   caLogger.setLevel(caConfig.LOG_LEVEL);
@@ -126,6 +128,20 @@ function startup(callback) {
             op: caConfig.OPERATION_TYPE.SERVER_START
           },
           'Server started at %s...', caServer.hapiServer.info.uri);
+
+        if (enableProofOfLifeLogging) {
+          proofOfLifeInterval = setInterval(function () {
+            caLogger.info(
+              {
+                op: caConfig.OPERATION_TYPE.SERVER_LOG
+              },
+              'Everything OK, %d requests attended in the last %ds interval...',
+              caServer.getKPIs().attendedRequests,
+              caConfig.PROOF_OF_LIFE_INTERVAL);
+            caServer.resetKPIs();
+          }, parseInt(caConfig.PROOF_OF_LIFE_INTERVAL, 10) * 1000);
+        }
+
         if (callback) {
           return process.nextTick(callback);
         }
@@ -134,21 +150,18 @@ function startup(callback) {
   );
 }
 
-// Starts the Context Adapter application up in case this file has not been 'require'd,
-//  such as, for example, for testing
-if (!module.parent) {
-  startup(function() {
-    proofOfLifeInterval = setInterval(function() {
-      caLogger.info(
-        {
-          op: caConfig.OPERATION_TYPE.SERVER_LOG
-        },
-        'Everything OK, %d requests attended in the last %ds interval...',
-        caServer.getKPIs().attendedRequests,
-        caConfig.PROOF_OF_LIFE_INTERVAL);
-      caServer.resetKPIs();
-    }, parseInt(caConfig.PROOF_OF_LIFE_INTERVAL, 10) * 1000);
-  });
+/**
+ * Convenience method to stop the Context Adapter
+ * @param callback Function to be called when the Context Adapter stops
+ * @return {*}
+ */
+function stop(callback) {
+  if (isStarted) {
+    return caServer.stop(callback);
+  }
+  if (callback) {
+    return process.nextTick(callback);
+  }
 }
 
 // In case Control+C is clicked, exit gracefully
@@ -163,12 +176,13 @@ process.on('uncaughtException', function(exception) {
 
 /**
  * Properties and functions exported by the module
- * @type {{server, startup: startup, exitGracefully: exitGracefully}}
+ * @type {{server, start: start, exitGracefully: exitGracefully}}
  */
 module.exports = {
   get server() {
     return caServer;
   },
-  startup: startup,
+  start: start,
+  stop: stop,
   exitGracefully: exitGracefully
 };

--- a/lib/context_adapter_server.js
+++ b/lib/context_adapter_server.js
@@ -368,11 +368,15 @@ function stop(callback) {
     server.stop(function(err) {
       // Server successfully stopped
       caLogger.info(context, 'hapi server successfully stopped');
-      callback(err);
+      if (callback) {
+        process.nextTick(callback.bind(null, err));
+      }
     });
   } else {
     caLogger.info(context, 'No hapi server running');
-    process.nextTick(callback);
+    if (callback) {
+      process.nextTick(callback);
+    }
   }
 }
 

--- a/test/unit/context_adapter_test.js
+++ b/test/unit/context_adapter_test.js
@@ -35,7 +35,37 @@ console.log('*** Running the Context Adapter unit tests with the following confi
 console.log(caConfig);
 
 describe('Context Adapter server:', function() {
-  it('should start successfully', function(done) {
+  it ('should stop the Context Adapter although not started:', function(done) {
+    contextAdapter.stop(function(err) {
+      expect(err).to.equal(undefined);
+      done();
+    })
+  });
+
+  it('should start the Context Adapter:', function(done) {
+    contextAdapter.start(false, function(err) {
+      expect(err).to.equal(undefined);
+      expect(contextAdapter.server.hapiServer).to.be.an.instanceof(hapi.Server);
+      done();
+    })
+  });
+
+  it ('should stop the Context Adapter when started:', function(done) {
+    contextAdapter.stop(function(err) {
+      expect(err).to.equal(undefined);
+      expect(contextAdapter.server.hapiServer.info.started).to.equal(0);
+      done();
+    })
+  });
+
+  it('should stop the Context Adapter server although not started', function(done) {
+    contextAdapter.server.stop(function(err) {
+      expect(err).to.equal(undefined);
+      done();
+    });
+  });
+
+  it('should start the Context Adapter server', function(done) {
     contextAdapter.server.start(caConfig.CA_HOST, caConfig.CA_PORT, function(err, hapiServer) {
       expect(err).to.equal(undefined);
       expect(hapiServer).to.be.an.instanceof(hapi.Server);


### PR DESCRIPTION
This functions let the user start the Context Adapter component enabling or not the proof on life logging, as well as stopping the Context Adapter if running.
- 100% tests passed
- Assigned to @dmoranj 
